### PR TITLE
Fix corrupt INT info in HPCC and TIMELY

### DIFF
--- a/astra-sim-alibabacloud/astra-sim/network_frontend/ns3/common.h
+++ b/astra-sim-alibabacloud/astra-sim/network_frontend/ns3/common.h
@@ -682,6 +682,7 @@ void SetConfig() {
     IntHeader::mode = IntHeader::NORMAL;
   else if (cc_mode == 10) 
     IntHeader::mode = IntHeader::PINT;
+  else
     IntHeader::mode = IntHeader::NONE;
 
   if (cc_mode == 10) {


### PR DESCRIPTION
Close #10 