### PR TITLE
[Fix] Integer overflow in network frontend causes premature termination of simulation with empty end-to-end results

### DIFF
--- a/astra-sim-alibabacloud/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
+++ b/astra-sim-alibabacloud/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
@@ -150,7 +150,7 @@ public:
     AstraSim::RecvPacketEventHadndlerData* ehd = (AstraSim::RecvPacketEventHadndlerData*) t.fun_arg;
     AstraSim::EventType event = ehd->event;
     tag = ehd->flowTag.tag_id;
-    NcclLog->writeLog(NcclLogLevel::DEBUG,"接收事件注册 src %d sim_recv on rank %d tag_id %d channdl id %d",src,rank,tag,ehd->flowTag.channel_id);
+    NcclLog->writeLog(NcclLogLevel::DEBUG,"[Receive event registration] src %d sim_recv on rank %d tag_id %d channdl id %d",src,rank,tag,ehd->flowTag.channel_id);
     
     if (recvHash.find(make_pair(tag, make_pair(t.src, t.dest))) !=
         recvHash.end()) {
@@ -190,12 +190,12 @@ public:
       if (expeRecvHash.find(make_pair(tag, make_pair(t.src, t.dest))) ==
           expeRecvHash.end()) {
         expeRecvHash[make_pair(tag, make_pair(t.src, t.dest))] = t;
-          NcclLog->writeLog(NcclLogLevel::DEBUG," 网络包后到，先进行注册 recvHash do not find expeRecvHash.new make src  %d dest  %d t.count:  %d channel_id  %d current_flow_id  %d",t.src,t.dest,t.count,tag,flowTag.current_flow_id);
+          NcclLog->writeLog(NcclLogLevel::DEBUG," [Packet arrived late, registering first] recvHash do not find expeRecvHash.new make src  %d dest  %d t.count:  %llu channel_id  %d current_flow_id  %d",t.src,t.dest,t.count,tag,flowTag.current_flow_id);
           
       } else {
         uint64_t expecount =
             expeRecvHash[make_pair(tag, make_pair(t.src, t.dest))].count;
-          NcclLog->writeLog(NcclLogLevel::DEBUG," 网络包后到，重复注册 recvHash do not find expeRecvHash.add make src  %d dest  %d expecount:  %d t.count:  %d tag_id  %d current_flow_id  %d",t.src,t.dest,expecount,t.count,tag,flowTag.current_flow_id);
+          NcclLog->writeLog(NcclLogLevel::DEBUG," [Packet arrived late, re-registering] recvHash do not find expeRecvHash.add make src  %d dest  %d expecount:  %d t.count:  %d tag_id  %d current_flow_id  %d",t.src,t.dest,expecount,t.count,tag,flowTag.current_flow_id);
           
       }
     }

--- a/astra-sim-alibabacloud/astra-sim/network_frontend/ns3/entry.h
+++ b/astra-sim-alibabacloud/astra-sim/network_frontend/ns3/entry.h
@@ -299,7 +299,7 @@ void notify_sender_packet_arrivered_receiver(int sender_node, int receiver_node,
 void qp_finish(FILE *fout, Ptr<RdmaQueuePair> q) {
   uint32_t sid = ip_to_node_id(q->sip), did = ip_to_node_id(q->dip);
   uint64_t base_rtt = pairRtt[sid][did], b = pairBw[sid][did];
-  uint32_t total_bytes =
+  uint64_t total_bytes =
       q->m_size +
       ((q->m_size - 1) / packet_payload_size + 1) *
           (CustomHeader::GetStaticWholeHeaderSize() -

--- a/astra-sim-alibabacloud/astra-sim/network_frontend/phynet/SimAiEntry.cc
+++ b/astra-sim-alibabacloud/astra-sim/network_frontend/phynet/SimAiEntry.cc
@@ -67,7 +67,7 @@ simai_send_finish(AstraSim::ncclFlowTag flowTag) {
   MockNcclLog* NcclLog = MockNcclLog::getInstance();
   NcclLog->writeLog(
       NcclLogLevel::DEBUG,
-      " 数据包出网卡队列, src %d did %d total_bytes %lu channel_id %d flow_id %d tag_id %d",
+      " [Packet dequeued from NIC TX queue], src %d did %d total_bytes %lu channel_id %d flow_id %d tag_id %d",
       sid,
       did,
       flowTag.flow_size,


### PR DESCRIPTION
## Problem Description
`recvHash` and `all_sent_chunksize` got integer overflow when the data size in collective communication is large, and there are implicit type conversions, leading to an early stop without an end-to-end result.

```cpp
map<std::pair<int, std::pair<int, int>>, int> recvHash;
uint64_t count = recvHash[make_pair(tag, make_pair(t.src, t.dest))]

int all_sent_chunksize;
notify_sender_sending_finished(sid, did, all_sent_chunksize, flowTag);
void notify_sender_sending_finished(int sender_node, int receiver_node, **uint64_t** message_size, AstraSim::ncclFlowTag flowTag)
```

## Observation
file: `ncclFlowModel_EndToEnd.csv` empty
file: `SimAI.log`, strange count, size and message size. and early stop.
<img width="830" alt="Pasted image 20250519023943" src="https://github.com/user-attachments/assets/423daecc-53a6-4ee5-b116-4a559337d8bc" />

## Minimal Reproduction
Workload
```
HYBRID_TRANSFORMER_FWD_IN_BCKWD model_parallel_NPU_group: 2 ep: 1 pp: 1 vpp: 36 ga: 1 all_gpus: 4 checkpoints: 0 checkpoint_initiates: 0 pp_comm: 0
2
grad_gather	-1	1	NONE	0	1	NONE	0	1	ALLGATHER	6467616768	100
grad_param_comm	-1	1	NONE	0	1	NONE	0	1	REDUCESCATTER	12935233536	100
```

Topology
```
7 2 2 1 8 H100
4 5 6 
0 4 2880Gbps 0.000025ms 0
0 6 100Gbps 0.0005ms 0
1 4 2880Gbps 0.000025ms 0
1 6 100Gbps 0.0005ms 0
2 5 2880Gbps 0.000025ms 0
2 6 100Gbps 0.0005ms 0
3 5 2880Gbps 0.000025ms 0
3 6 100Gbps 0.0005ms 0
```

## Change Made:
1. Update type of recvHash and all_sent_chunksize.
2. Fix the relevant output log format specifiers and update to consistent language.
