### PR TITLE
recover initChannel coredump

### DIFF
--- a/SimCCL/src/channel.cc
+++ b/SimCCL/src/channel.cc
@@ -55,8 +55,8 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
   ncclCommPushCudaFree(comm, channel->devRingUserRanks);
 
   /* guarantee addr has been copied into channel->devPeers */
-  NCCLCHECK(ncclStrongStreamSynchronize(&sharedRes->deviceStream));
-  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(), &sharedRes->deviceStream));
+  // NCCLCHECK(ncclStrongStreamSynchronize(&sharedRes->deviceStream));
+  // NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(), &sharedRes->deviceStream));
 
   return ncclSuccess;
 }

--- a/SimCCL/src/graph/paths.cc
+++ b/SimCCL/src/graph/paths.cc
@@ -770,6 +770,10 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
   comm->p2pnChannels = nextPow2(comm->p2pnChannels);
 
   // Init channels that weren't used so far
+  for (int r = 0; r < comm->nRanks; ++r)
+  {
+    comm->topParentRanks[r] = r;
+  }
   for (int c=comm->nChannels; c<comm->p2pnChannels; c++) NCCLCHECK(initChannel(comm, c));
 
   // We want to spread channels used when there aren't many and progressively


### PR DESCRIPTION
1.recover when comm->nChannels not equal to comm->p2pnChannels and initChannel is called, then coredump
2.this change causes no affection to the simulation time，tests based by the xml in SimCCL/test