### PR TITLE
[Fix] Double free

### DIFF
--- a/astra-sim-alibabacloud/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
+++ b/astra-sim-alibabacloud/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
@@ -150,7 +150,7 @@ public:
     AstraSim::RecvPacketEventHadndlerData* ehd = (AstraSim::RecvPacketEventHadndlerData*) t.fun_arg;
     AstraSim::EventType event = ehd->event;
     tag = ehd->flowTag.tag_id;
-    NcclLog->writeLog(NcclLogLevel::DEBUG,"接收事件注册 src %d sim_recv on rank %d tag_id %d channdl id %d",src,rank,tag,ehd->flowTag.channel_id);
+    NcclLog->writeLog(NcclLogLevel::DEBUG,"[Receive event registration] src %d sim_recv on rank %d tag_id %d channdl id %d",src,rank,tag,ehd->flowTag.channel_id);
     
     if (recvHash.find(make_pair(tag, make_pair(t.src, t.dest))) !=
         recvHash.end()) {
@@ -190,12 +190,12 @@ public:
       if (expeRecvHash.find(make_pair(tag, make_pair(t.src, t.dest))) ==
           expeRecvHash.end()) {
         expeRecvHash[make_pair(tag, make_pair(t.src, t.dest))] = t;
-          NcclLog->writeLog(NcclLogLevel::DEBUG," 网络包后到，先进行注册 recvHash do not find expeRecvHash.new make src  %d dest  %d t.count:  %d channel_id  %d current_flow_id  %d",t.src,t.dest,t.count,tag,flowTag.current_flow_id);
+          NcclLog->writeLog(NcclLogLevel::DEBUG," [Packet arrived late, registering first] recvHash do not find expeRecvHash.new make src  %d dest  %d t.count:  %llu channel_id  %d current_flow_id  %d",t.src,t.dest,t.count,tag,flowTag.current_flow_id);
           
       } else {
         uint64_t expecount =
             expeRecvHash[make_pair(tag, make_pair(t.src, t.dest))].count;
-          NcclLog->writeLog(NcclLogLevel::DEBUG," 网络包后到，重复注册 recvHash do not find expeRecvHash.add make src  %d dest  %d expecount:  %d t.count:  %d tag_id  %d current_flow_id  %d",t.src,t.dest,expecount,t.count,tag,flowTag.current_flow_id);
+          NcclLog->writeLog(NcclLogLevel::DEBUG," [Packet arrived late, re-registering] recvHash do not find expeRecvHash.add make src  %d dest  %d expecount:  %d t.count:  %d tag_id  %d current_flow_id  %d",t.src,t.dest,expecount,t.count,tag,flowTag.current_flow_id);
           
       }
     }

--- a/astra-sim-alibabacloud/astra-sim/system/MockNcclGroup.cc
+++ b/astra-sim-alibabacloud/astra-sim/system/MockNcclGroup.cc
@@ -2022,7 +2022,7 @@ namespace MockNccl {
         q.push(current->right);
       }
     }
-    return node2treenode[(nodes[rank2index[root->node]+1]) % nodes.size()];
+    return node2treenode[nodes[(rank2index[root->node] + 1) % nodes.size()]];
   }
 
   ncclInfo* MockNcclGroup::get_algo_proto_info(


### PR DESCRIPTION
This issue #117 will trigger double free #89, which usually occurs in large topologies and workloads
`double free or corruption (!prev)` 
`double free or corruption (out)` 

previous commit based on #127 
