### PR TITLE
fix wrong check in genAllGather excluding rank 0 from prev

### DIFF
--- a/astra-sim-alibabacloud/astra-sim/system/MockNcclGroup.cc
+++ b/astra-sim-alibabacloud/astra-sim/system/MockNcclGroup.cc
@@ -1598,7 +1598,7 @@ namespace MockNccl {
               result[std::make_pair(ring_id, g_flow_id)] = tmp_result;
               g_flow_id++;
               prevranks.clear();
-              if(rank_it->first){
+              if(rank_it->first!=-1){
                 prevranks = {rank_it->first};
               }
               tmp_result = SingleFlow(


### PR DESCRIPTION
There is an error when initializing prevranks as `prevranks = {rank_it->first}`, which should be skipped in case the rank is -1.
Only in the AllGather, only for the PXN case, and only for chunkid > 0, this check is wrong: `if (rank_it->first) {...}`, which skips the case where the rank is 0, instead of -1.