### PR TITLE
Fix double-free race condition in NcclTreeFlowModel execution logic

### DIFF
--- a/astra-sim-alibabacloud/astra-sim/system/collective/NcclTreeFlowModel.cc
+++ b/astra-sim-alibabacloud/astra-sim/system/collective/NcclTreeFlowModel.cc
@@ -433,9 +433,14 @@ bool NcclTreeFlowModel::iteratable(int channel_id) {
       break;
     }
   }
+  bool should_exit = false;
+  if (all_channel_finished && all_packets_freed) {
+    if (!judge_exit_flag.exchange(true)) {
+      should_exit = true;
+    }
+  }
   cs.ExitSection();
-  if (all_channel_finished == true &&
-      all_packets_freed == true) {
+  if (should_exit) {
     exit();
     return false;
   }


### PR DESCRIPTION
## Description
Fixes a critical race condition in `NcclTreeFlowModel::iteratable` causing "double free" crashes (SIGABRT) under high-concurrency scenarios, particularly when running fine-grained workloads or low-latency network configurations.

## Crash Log
```text
info: reduce-scatter forward pass collective issued for layer: mlp_row, involved dimensions: 1, 0, 0...
***** info: fwd pass comm collective for layer: mlp_row is finished************
double free or corruption (out)
Aborted (core dumped)
```

## The Issue
A **TOCTOU (Time-of-Check to Time-of-Use)** vulnerability exists because the exit condition is checked **after** releasing the lock:
```cpp
cs.ExitSection(); // Lock released
if (all_channel_finished == true && all_packets_freed == true) {
    exit(); // <--- Race condition: multiple threads can enter here
    return false;
}
```

## The Fix

Utilized the existing atomic `judge_exit_flag.exchange(true)` to ensure `exit()` is called **exactly once**, regardless of thread interleaving.