### PR TITLE
Removing `cd` to undefined `BUILD_DIR`. Each component has its own `cd` so this line is not necessary.

### DIFF
--- a/astra-sim-alibabacloud/build.sh
+++ b/astra-sim-alibabacloud/build.sh
@@ -44,7 +44,6 @@ function compile {
     mkdir -p "${SIM_LOG_DIR}"/topo/
     mkdir -p "${SIM_LOG_DIR}"/results/
     local option="$1" 
-    cd "${BUILD_DIR}" || exit
     case "$option" in
     "ns3")
         cd "${NS3_BUILD_DIR}"


### PR DESCRIPTION
This is causing build.sh script to fail when running: ./scripts/build.sh -c analytical.
Solves issue #249  