### PR TITLE
docs: fix analytical bandwidth parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ astra-sim-alibabacloud is extended from [astra-sim](https://github.com/astra-sim
 
 SimAI supports three major operation modes to meet different simulation requirements:
 
-**SimAI-Analytical** offers fast simulation by abstracting network communication details using bus bandwidth (busbw) to estimate collective communication time. While it currently supports user-defined busbw, automatic busbw calculation feature is coming soon.
+**SimAI-Analytical** offers fast simulation by abstracting network communication details using configured NVLink and NIC bandwidth values to estimate collective communication time. Automatic bus bandwidth calculation feature is coming soon.
 
 **SimAI-Simulation** provides full-stack simulation with fine-grained network communication modeling. It leverages NS3 or other network simulators (NS3 currently open-sourced) to achieve detailed simulation of all communication behaviors, aiming for high-fidelity reproduction of actual training environments.
 
@@ -179,11 +179,7 @@ $ ./scripts/build.sh -c ns3
 
 ## Use SimAI-Analytical
 
-```bash
-$ ./bin/SimAI_analytical -w example/workload_analytical.txt -g 9216 -g_p_s 8 -r test- -busbw example/busbw.yaml
-```
-
-For calculating bus bandwidth automatically, please try the following command:
+Provide the supported bandwidth parameters explicitly:
 
 ```bash
 $ ./bin/SimAI_analytical -w ./example/workload_analytical.txt -g 9216 -nv 360 -nic 48.5 -n_p_s 8 -g_p_s 8 -r example-

--- a/astra-sim-alibabacloud/astra-sim/system/AstraParamParse.hh
+++ b/astra-sim-alibabacloud/astra-sim/system/AstraParamParse.hh
@@ -107,7 +107,7 @@ int parse(int argc, char *argv[]) {
             std::cout << "-r,     --result            Output results path" << std::endl;
             std::cout << "-nv, --nvlink     Nvlink" << std::endl;
             std::cout << "-nic, --nic_busbw     NIC busbw" << std::endl;
-            std::cout << "-n_p_s, --bus-bandwidth     Bus bandwidth file" << std::endl;
+            std::cout << "-n_p_s, --nic_per_server     NICs per server" << std::endl;
             std::cout << "-nic_t, --nic_type     NIC type(cx7,bf3),choose when disable nic " << std::endl;
             std::cout << "-g_type, --gpu_type     GPU type(A100,H100),choose when disable nvlink " << std::endl;
             std::cout << "-v, --visual    Enable visual output" << std::endl;


### PR DESCRIPTION
Closes #227.

## Summary
- replace the unsupported `-busbw` analytical example with the currently parsed `-nv`, `-nic`, and `-n_p_s` parameters
- update the analytical mode description to avoid referring to a bus bandwidth file option
- fix the help text for `-n_p_s` so it documents `--nic_per_server`

## Verification
- `git diff --check`
- `rg -n -- "-busbw|--bus-bandwidth" README.md astra-sim-alibabacloud/astra-sim/system/AstraParamParse.hh`