### PR TITLE
test(vidur): cover AICB KV cache save predictions

### DIFF
--- a/vidur-alibabacloud/tests/test_aicb_execution_time_predictor.py
+++ b/vidur-alibabacloud/tests/test_aicb_execution_time_predictor.py
@@ -1,0 +1,36 @@
+"""Regression tests for the AICB execution-time predictor."""
+
+from types import SimpleNamespace
+
+from vidur.execution_time_predictor.sklearn_execution_time_predictor import (
+    SklearnExecutionTimePredictor,
+)
+
+
+def test_aicb_compute_predictions_include_kv_cache_save():
+    """AICB batches must be able to account for KV-cache-save execution time.
+
+    This guards the failure reported in SimAI issue #266, where the AICB
+    prediction table omitted the key consumed by
+    ``_get_attention_kv_cache_save_execution_time``.
+    """
+    predictor = object.__new__(SklearnExecutionTimePredictor)
+    predictor._replica_config = SimpleNamespace(
+        num_pipeline_stages=1,
+        tensor_parallel_size=1,
+    )
+    predictor._max_tokens = 4
+
+    predictions = predictor._predict_for_compute_models_by_aicb()
+
+    assert "attn_kv_cache_save" in predictions
+    assert set(predictions["attn_kv_cache_save"]) == {
+        (1,),
+        (2,),
+        (3,),
+        (4,),
+    }
+    assert all(
+        prediction >= 0
+        for prediction in predictions["attn_kv_cache_save"].values()
+    )


### PR DESCRIPTION
## Summary

Add a focused regression test for the AICB execution-time predictor to ensure it always publishes the `attn_kv_cache_save` table consumed by Vidur batch execution.

This protects the failure reported in #266. The current master implementation contains the prediction after the SimAI 1.6 merge, but the behavior had no automated coverage and the issue remains open.

## Test coverage

- verifies the AICB table contains `attn_kv_cache_save`;
- verifies every token count in the configured prediction range is populated;
- verifies generated execution times are non-negative.

## Validation

- `git diff --check`
- Python 3.11 remote H20 syntax smoke for the predictor and regression test (`ede4acc`)

A full pytest run requires the Vidur Python dependency environment; the remote H20 base OS does not carry those packages.

Fixes regression coverage for #266.