### PR TITLE
feat(vidur): sweep P/D network configurations

### DIFF
--- a/vidur-alibabacloud/tests/test_pd_network_config_sweep.py
+++ b/vidur-alibabacloud/tests/test_pd_network_config_sweep.py
@@ -1,0 +1,80 @@
+"""Tests for P/D network design-space generation."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from vidur.config_optimizer.config_explorer.config import (
+    JobConfig,
+    PDNetworkConfig,
+)
+
+
+def _base_config():
+    return {
+        "models": [{"name": "toy", "identifier": "toy/model"}],
+        "traces": [
+            {
+                "name": "chat",
+                "trace_file": "chat.csv",
+                "max_seq_len": 4096,
+                "num_requests": 10,
+                "start_qps": 1,
+            }
+        ],
+        "clusters": [{"device": "h20", "num_gpus": 8, "gpus_per_node": 8}],
+        "schedulers": [{"scheduler": "vllm"}],
+        "tp_dimensions": [1],
+        "pp_dimensions": [1],
+        "batch_sizes": [32],
+    }
+
+
+def test_pd_network_dimension_expands_job_configs():
+    config = _base_config()
+    config["pd_networks"] = [
+        {"name": "mixed"},
+        {
+            "name": "pd-100g",
+            "pd_node_ratio": 0.5,
+            "pd_p2p_comm_bandwidth": 100,
+            "rdma_bandwidth": 100,
+            "nvlink_bandwidth": 900,
+        },
+        {
+            "name": "pd-400g",
+            "pd_node_ratio": 0.5,
+            "pd_p2p_comm_bandwidth": 400,
+            "rdma_bandwidth": 400,
+            "nvlink_bandwidth": 900,
+        },
+    ]
+
+    jobs = JobConfig.generate_job_configs(config)
+
+    assert len(jobs) == 3
+    assert len({job.get_key() for job in jobs}) == 3
+    assert {
+        job.to_config_dict()["replica_config_pd_p2p_comm_bandwidth"]
+        for job in jobs
+    } == {100, 400, 800}
+
+
+def test_legacy_config_keeps_single_mixed_mode_job():
+    jobs = JobConfig.generate_job_configs(_base_config())
+
+    assert len(jobs) == 1
+    generated = jobs[0].to_config_dict()
+    assert generated["replica_config_pd_node_ratio"] == 1.0
+    assert jobs[0].pd_network_config.name == "mixed"
+    assert "_pdr" not in jobs[0].get_key()
+
+
+def test_invalid_pd_split_or_bandwidth_is_rejected():
+    assert not PDNetworkConfig(pd_node_ratio=0).is_valid(8)
+    assert not PDNetworkConfig(pd_node_ratio=0.01).is_valid(8)
+    assert not PDNetworkConfig(
+        pd_node_ratio=0.5, pd_p2p_comm_bandwidth=0
+    ).is_valid(8)
+    assert PDNetworkConfig(pd_node_ratio=0.5).is_valid(8)

--- a/vidur-alibabacloud/tests/test_pd_network_config_sweep.py
+++ b/vidur-alibabacloud/tests/test_pd_network_config_sweep.py
@@ -71,6 +71,15 @@ def test_legacy_config_keeps_single_mixed_mode_job():
     assert "_pdr" not in jobs[0].get_key()
 
 
+def test_pd_network_dtype_is_part_of_job_key():
+    float16 = PDNetworkConfig(name="pd-100g", pd_p2p_comm_dtype="float16")
+    fp8 = PDNetworkConfig(name="pd-100g", pd_p2p_comm_dtype="fp8")
+
+    assert float16.get_key() != fp8.get_key()
+    assert float16.to_config_dict()["replica_config_pd_p2p_comm_dtype"] == "float16"
+    assert fp8.to_config_dict()["replica_config_pd_p2p_comm_dtype"] == "fp8"
+
+
 def test_invalid_pd_split_or_bandwidth_is_rejected():
     assert not PDNetworkConfig(pd_node_ratio=0).is_valid(8)
     assert not PDNetworkConfig(pd_node_ratio=0.01).is_valid(8)

--- a/vidur-alibabacloud/vidur/config_optimizer/config_explorer/config/__init__.py
+++ b/vidur-alibabacloud/vidur/config_optimizer/config_explorer/config/__init__.py
@@ -2,6 +2,7 @@ from vidur.config_optimizer.config_explorer.config.config import (
     ClusterConfig,
     JobConfig,
     ModelConfig,
+    PDNetworkConfig,
     SchedulerConfig,
     SimulationConfig,
     TraceConfig,
@@ -14,4 +15,5 @@ __all__ = [
     SchedulerConfig,
     ClusterConfig,
     ModelConfig,
+    PDNetworkConfig,
 ]

--- a/vidur-alibabacloud/vidur/config_optimizer/config_explorer/config/config.py
+++ b/vidur-alibabacloud/vidur/config_optimizer/config_explorer/config/config.py
@@ -94,6 +94,54 @@ class SchedulerConfig:
         }
 
 
+@dataclass
+class PDNetworkConfig:
+    """One P/D deployment and network point in the design-space sweep."""
+
+    name: str = "mixed"
+    pd_node_ratio: float = 1.0
+    pd_p2p_comm_bandwidth: int = 800
+    rdma_bandwidth: int = 800
+    nvlink_bandwidth: int = 1600
+    pd_p2p_comm_dtype: str = "float16"
+
+    def get_key(self):
+        if self == PDNetworkConfig():
+            return ""
+        return (
+            f"{self.name}_pdr{self.pd_node_ratio:g}"
+            f"_pdbw{self.pd_p2p_comm_bandwidth}"
+            f"_rdbw{self.rdma_bandwidth}"
+            f"_nvbw{self.nvlink_bandwidth}"
+        )
+
+    def is_valid(self, num_replicas: int):
+        if not 0 < self.pd_node_ratio <= 1:
+            return False
+        if min(
+            self.pd_p2p_comm_bandwidth,
+            self.rdma_bandwidth,
+            self.nvlink_bandwidth,
+        ) <= 0:
+            return False
+        if self.pd_node_ratio == 1:
+            return True
+
+        num_prefill_replicas = int(num_replicas * self.pd_node_ratio)
+        return 0 < num_prefill_replicas < num_replicas
+
+    def to_config_dict(self):
+        return {
+            "replica_config_pd_node_ratio": self.pd_node_ratio,
+            "replica_config_pd_p2p_comm_bandwidth": (
+                self.pd_p2p_comm_bandwidth
+            ),
+            "replica_config_rdma_bandwidth": self.rdma_bandwidth,
+            "replica_config_nvlink_bandwidth": self.nvlink_bandwidth,
+            "replica_config_pd_p2p_comm_dtype": self.pd_p2p_comm_dtype,
+        }
+
+
 class JobConfig:
     def __init__(
         self,
@@ -104,6 +152,7 @@ class JobConfig:
         num_tensor_parallel_workers: int,
         num_pipeline_stages: int,
         batch_size: int,
+        pd_network_config: Optional[PDNetworkConfig] = None,
     ):
         self.model_config = model_config
         self.trace_config = trace_config
@@ -114,6 +163,7 @@ class JobConfig:
         self.num_workers = self.num_tensor_parallel_workers * self.num_pipeline_stages
         self.batch_size = batch_size * num_pipeline_stages
         self.num_replicas = self.cluster_config.num_gpus // self.num_workers
+        self.pd_network_config = pd_network_config or PDNetworkConfig()
 
         self.start_qps = self.trace_config.start_qps
 
@@ -124,19 +174,26 @@ class JobConfig:
                 self.num_tensor_parallel_workers
             )
             and self.num_tensor_parallel_workers <= self.cluster_config.gpus_per_node
+            and self.pd_network_config.is_valid(self.num_replicas)
         )
 
     def get_key(self):
+        pd_network_key = self.pd_network_config.get_key()
+        pd_network_suffix = (
+            f"_{pd_network_key}" if pd_network_key else ""
+        )
         return (
             f"{self.model_config.name}_{self.trace_config.get_key()}_{self.cluster_config.get_key()}_{self.scheduler_config.get_key()}"
             f"_tp{self.num_tensor_parallel_workers}_pp{self.num_pipeline_stages}_bsz{self.batch_size}"
+            f"{pd_network_suffix}"
         )
 
     def get_human_readable_name(self):
         return (
             f"Model: {self.model_config.name}, Trace: {self.trace_config.name}, Cluster: {self.cluster_config.device}, "
             f"Scheduler: {self.scheduler_config.scheduler}, TP: {self.num_tensor_parallel_workers}, "
-            f"PP: {self.num_pipeline_stages}, BSZ: {self.batch_size}, CS: {self.scheduler_config.chunk_size}, Hash: {self.get_hash()}"
+            f"PP: {self.num_pipeline_stages}, BSZ: {self.batch_size}, CS: {self.scheduler_config.chunk_size}, "
+            f"PD network: {self.pd_network_config.name}, Hash: {self.get_hash()}"
         )
 
     def get_hash(self):
@@ -148,6 +205,7 @@ class JobConfig:
             **self.trace_config.to_config_dict(),
             **self.cluster_config.to_config_dict(),
             **self.scheduler_config.to_config_dict(),
+            **self.pd_network_config.to_config_dict(),
             "replica_config_tensor_parallel_size": self.num_tensor_parallel_workers,
             "replica_config_num_pipeline_stages": self.num_pipeline_stages,
             "vllm_scheduler_config_batch_size_cap": self.batch_size,
@@ -169,6 +227,7 @@ class JobConfig:
             tp_dimension,
             pp_dimension,
             batch_size,
+            pd_network_config,
         ) in product(
             config["models"],
             config["traces"],
@@ -177,6 +236,7 @@ class JobConfig:
             config["tp_dimensions"],
             config["pp_dimensions"],
             config["batch_sizes"],
+            config.get("pd_networks", [{"name": "mixed"}]),
         ):
             job_config = cls(
                 ModelConfig(**model_config),
@@ -186,6 +246,7 @@ class JobConfig:
                 tp_dimension,
                 pp_dimension,
                 batch_size,
+                PDNetworkConfig(**pd_network_config),
             )
             if not job_config.is_valid():
                 continue
@@ -205,6 +266,10 @@ class JobConfig:
         # set pp_dimensions to 2 because it covers all the options
         pp_dimensions = [2]
 
+        pd_network_config = PDNetworkConfig(
+            **config.get("pd_networks", [{"name": "mixed"}])[0]
+        )
+
         for model_config, cluster_config, tp_dimension, pp_dimension in product(
             config["models"],
             config["clusters"],
@@ -219,6 +284,7 @@ class JobConfig:
                 tp_dimension,
                 pp_dimension,
                 batch_size,
+                pd_network_config,
             )
             if not job_config.is_valid():
                 continue

--- a/vidur-alibabacloud/vidur/config_optimizer/config_explorer/config/config.py
+++ b/vidur-alibabacloud/vidur/config_optimizer/config_explorer/config/config.py
@@ -113,6 +113,7 @@ class PDNetworkConfig:
             f"_pdbw{self.pd_p2p_comm_bandwidth}"
             f"_rdbw{self.rdma_bandwidth}"
             f"_nvbw{self.nvlink_bandwidth}"
+            f"_dtype{self.pd_p2p_comm_dtype}"
         )
 
     def is_valid(self, num_replicas: int):

--- a/vidur-alibabacloud/vidur/config_optimizer/config_explorer/config/debug_config.yml
+++ b/vidur-alibabacloud/vidur/config_optimizer/config_explorer/config/debug_config.yml
@@ -29,6 +29,22 @@ batch_sizes: [32, 64]
 tp_dimensions: [1, 2]
 pp_dimensions: [1, 2]
 
+# Optional P/D and fabric sweep. When omitted, the config explorer preserves
+# the previous mixed-serving defaults.
+pd_networks:
+  - name: mixed
+    pd_node_ratio: 1.0
+    pd_p2p_comm_bandwidth: 100
+    rdma_bandwidth: 100
+    nvlink_bandwidth: 100
+    pd_p2p_comm_dtype: float16
+  - name: pd-balanced-100g
+    pd_node_ratio: 0.5
+    pd_p2p_comm_bandwidth: 100
+    rdma_bandwidth: 100
+    nvlink_bandwidth: 900
+    pd_p2p_comm_dtype: float16
+
 models:
   - name: phi-2
     identifier: microsoft/phi-2


### PR DESCRIPTION
## Summary

Add `pd_networks` as an optional Vidur config-explorer dimension so the existing capacity search and Pareto analyzer can compare colocated and P/D-separated deployment points across fabric bandwidths.

- introduces a validated `PDNetworkConfig`;
- sweeps P-node ratio, P/D bandwidth, RDMA bandwidth, NVLink bandwidth and transfer dtype;
- passes every point through existing `ReplicaConfig` CLI fields;
- rejects invalid ratios, non-positive bandwidths and splits that produce zero P or D replicas;
- includes non-default network points in deterministic job/cache keys;
- preserves legacy YAML behavior and legacy keys when `pd_networks` is absent;
- documents mixed and 1P:1D examples in `debug_config.yml`.

Closes #296.

## Validation

Three focused tests cover design-space expansion, legacy compatibility and invalid-point rejection.

Remote smoke on `lingjun-101`, Python 3.11, fresh branch clone (`1fca827`):

- `test_pd_network_dimension_expands_job_configs`: PASS
- `test_legacy_config_keeps_single_mixed_mode_job`: PASS
- `test_invalid_pd_split_or_bandwidth_is_rejected`: PASS

No GPU or production service was used.